### PR TITLE
Fix: `undefined` object properties for resourceItemStatementModel

### DIFF
--- a/js/js/statementModel.js
+++ b/js/js/statementModel.js
@@ -397,10 +397,10 @@ define([
       const model = new Backbone.Model();
 
       model.set({
-        _id: (data.type === 'document') ? data.filename : '?' + data.href,
+        _id: (data.type === 'document') ? data.filename : '?link=' + data._link,
         title: data.title,
         description: data.description,
-        url: (data.type === 'document') ? data.filename : data.href
+        url: (data.type === 'document') ? data.filename : data._link
       });
 
       this.sendResourceExperienced(model);


### PR DESCRIPTION
Fixes #24.

### Fix
* `undefined` object properties for _experienced_ resource item statements:
  *  `undefined` `object.id` suffix
  * missing `object.moreInfo` property due to `undefined` `url` property


