### PR TITLE
Fix: added answered statement for the confidenceSlider (fixes #26).

### DIFF
--- a/js/statementModel.js
+++ b/js/statementModel.js
@@ -8,13 +8,14 @@ define([
   './statements/experiencedStatementModel',
   './statements/mcqStatementModel',
   './statements/sliderStatementModel',
+  './statements/confidenceSliderStatementModel',
   './statements/textInputStatementModel',
   './statements/matchingStatementModel',
   './statements/assessmentStatementModel',
   './statements/resourceItemStatementModel',
   './statements/favouriteStatementModel',
   './statements/unfavouriteStatementModel'
-], function(Adapt, COMPLETION_STATE, InitializedStatementModel, TerminatedStatementModel, PreferredLanguageStatementModel, CompletedStatementModel, ExperiencedStatementModel, McqStatementModel, SliderStatementModel, TextInputStatementModel, MatchingStatementModel, AssessmentStatementModel, ResourceItemStatementModel, FavouriteStatementModel, UnfavouriteStatementModel) {
+], function(Adapt, COMPLETION_STATE, InitializedStatementModel, TerminatedStatementModel, PreferredLanguageStatementModel, CompletedStatementModel, ExperiencedStatementModel, McqStatementModel, SliderStatementModel, ConfidenceSliderStatementModel, TextInputStatementModel, MatchingStatementModel, AssessmentStatementModel, ResourceItemStatementModel, FavouriteStatementModel, UnfavouriteStatementModel) {
 
   const StatementModel = Backbone.Model.extend({
 
@@ -176,6 +177,9 @@ define([
           break;
         case 'slider':
           statementClass = SliderStatementModel;
+          break;
+        case 'confidenceSlider':
+          statementClass = ConfidenceSliderStatementModel;
           break;
         case 'textinput':
           statementClass = TextInputStatementModel;

--- a/js/statements/confidenceSliderStatementModel.js
+++ b/js/statements/confidenceSliderStatementModel.js
@@ -1,0 +1,20 @@
+define([
+  './sliderStatementModel'
+], function(SliderStatementModel) {
+
+  const ConfidenceSliderStatementModel = SliderStatementModel.extend({
+
+    getResult: function(model) {
+      const result = {
+        completion: model.get('_isComplete'),
+        response: this.getResponse(model)
+      };
+
+      return result;
+    },
+
+  });
+
+  return ConfidenceSliderStatementModel;
+
+});


### PR DESCRIPTION
Fixes #26.

### Fix
* added _answered_ statement for the confidenceSlider - excludes `score` and `success` from the `result`.


