### PR TITLE
Fix: fetch-polyfill `init` error

### DIFF
--- a/libraries/fetch-polyfill.js
+++ b/libraries/fetch-polyfill.js
@@ -456,7 +456,7 @@
       }
 
       const xhr = new XMLHttpRequest();
-      const isAsync = !(init.keepalive || false);
+      const isAsync = !(init?.keepalive ?? false);
 
       if (isAsync) {
         function abortXhr() {


### PR DESCRIPTION
Fixes #19.

### Fix
* Added optional chaining to account for `fetch` calls without `init` settings, previously causing an error when checking `init.keepalive`.